### PR TITLE
헤더에 로고 텍스트나 브라우저 타이틀이 길면 벗어남

### DIFF
--- a/layouts/rx-flextagram/components/header/header.scss
+++ b/layouts/rx-flextagram/components/header/header.scss
@@ -61,11 +61,6 @@ $header-height: 52px;
   align-items: center;
 }
 
-.app-header__left,
-.app-header__right {
-  width: 250px;
-}
-
 .app-header__right {
   justify-content: flex-end;
 }
@@ -73,6 +68,13 @@ $header-height: 52px;
 .app-header__center {
   flex: 1;
   justify-content: center;
+}
+
+.app-header-logo,
+.app-header__browser-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .app-header-logo {
@@ -91,18 +93,25 @@ $header-height: 52px;
 
   transition: .2s ease;
 
+  max-width: 180px;
+
+  @media (max-width: $mobile-w) {
+    max-width: 120px;
+  }
+
   & > img,
   & > svg {
     display: block;
     width: auto;
-    height: 2.875rem;
-    height: $logo-height;
+    max-height: 2.875rem;
+    max-height: $logo-height;
+    max-width: 100%;
     fill: $color-gray-900;
     fill: var(--color-gray-900);
 
     @media (max-width: $mobile-w) {
-      height: 2.5rem;
-      height: $logo-height;
+      max-height: 2.5rem;
+      max-height: $logo-height;
     }
   }
 
@@ -119,6 +128,11 @@ $header-height: 52px;
   font-size: 1rem;
   font-weight: 500;
   text-decoration: none;
+  max-width: 170px;
+
+  @media (max-width: $mobile-w) {
+    max-width: 150px;
+  }
 
   &::before {
     content: "–";

--- a/layouts/rx-flextagram/conf/info.xml
+++ b/layouts/rx-flextagram/conf/info.xml
@@ -142,8 +142,8 @@
             </var>
 
             <var name="logo_height" type="text">
-                <title xml:lang="ko">로고 높이</title>
-                <description xml:lang="ko">로고 이미지의 높이를 조정할 수 있습니다. (px, rem 단위 지원, 기본값: 2.875rem)</description>
+                <title xml:lang="ko">로고 최대 높이</title>
+                <description xml:lang="ko">로고 이미지의 최대 높이를 조정할 수 있습니다. (px, rem 단위 지원, 기본값: 2.875rem)</description>
             </var>
 
             <var name="logo_text" type="text">


### PR DESCRIPTION
before
![before](https://user-images.githubusercontent.com/60917154/118493679-53754280-b75c-11eb-9c39-12995b9f0750.png)

after
![pc화면](https://user-images.githubusercontent.com/60917154/118493738-64be4f00-b75c-11eb-8044-84592b808adc.png)
![모바일320](https://user-images.githubusercontent.com/60917154/118493744-65ef7c00-b75c-11eb-84fd-73c5e0ecd72f.png)

또한, 로고 이미지 사이즈 관련 문제도 fix 했습니다.